### PR TITLE
reformatted, clean up, and fix the syntax

### DIFF
--- a/third_party/freenove/smart_car/setup.sh
+++ b/third_party/freenove/smart_car/setup.sh
@@ -19,11 +19,11 @@ echo "Starting the setup in five seconds..."
 echo "Press ctrl + c to stop the setup immediately"
 sleep 5
 echo "Installing..."
-sudo apt install -y python3-pip
-sudo pip3 install zmq
 sudo apt-get install -y python3-dev python3-rpi.gpio
 sudo apt-get install -y python3-smbus
-sudo pip3 install -y rpi_ws281x
+sudo apt install -y python3-pip
+sudo pip3 install zmq
+sudo pip3 install rpi_ws281x
 sudo groupadd gpio
 sudo usermod -aG gpio "${USER}"
 echo "Setup is complete!"


### PR DESCRIPTION
- Remove the `-y` on pip3 install
- Reformatted code a little
![image](https://user-images.githubusercontent.com/65916520/188217702-41f973c5-9647-42d9-af0a-91acb030e1a9.png)
